### PR TITLE
gradle-versions-plugin (adds task to detect dependency updates)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
+apply plugin: 'com.github.ben-manes.versions'
 buildscript {
     repositories {
         jcenter()
     }
     dependencies {
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.11.3'
         classpath 'com.android.tools.build:gradle:1.2.3'
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
This commit adds the [gradle-version-plugin](https://github.com/ben-manes/gradle-versions-plugin) which provides a Gradle task (``dependencyUpdates``) to determine which dependencies have updates.

Checking for updates shouldn't snag our work and this plugin did a really good job in other projects I worked on.